### PR TITLE
Set the test directory to "test"

### DIFF
--- a/src/rails-workspace.ts
+++ b/src/rails-workspace.ts
@@ -30,7 +30,7 @@ export class RailsWorkspace {
   }
 
   get testPath(): string {
-    return path.join(this.path, 'tests');
+    return path.join(this.path, 'test');
   }
 
   get controllersPath(): string {


### PR DESCRIPTION
The default test directory in a newly created Rails app is "test", not "tests", so I've removed the "s" which should enable the fixture/model/test switching to work properly.