### PR TITLE
Fix getTestPath function to correct test path

### DIFF
--- a/src/rails-workspace.ts
+++ b/src/rails-workspace.ts
@@ -210,8 +210,8 @@ export function getTestPath(
   );
 
   return path.join(
-    workspace.specPath,
-    appendWithoutExt(relFn(railsFile.filename), '_spec')
+    workspace.testPath,
+    appendWithoutExt(relFn(railsFile.filename), '_test')
   );
 }
 


### PR DESCRIPTION
Currently, using Minitest, when you don't have the test file for a given file and try to use the shortcut to go to it, the extension tries to create the file as a spec as shown in print:
<img width="1913" alt="image" src="https://github.com/jemmyw/vscode-rails-fast-nav/assets/53313927/14192810-0589-44f6-85bc-684c38eab0cb">

This occurs because there is an error in its return, the `getTestPath` function has its return set with the spec values. This PR is to fix this. Thus, the suggestion for creating the file will be:
<img width="1908" alt="image" src="https://github.com/jemmyw/vscode-rails-fast-nav/assets/53313927/c72274bd-8873-4c27-934c-53721da93f9f">