### PR TITLE
Improve view to controller navigation

### DIFF
--- a/src/makers/controller-maker.ts
+++ b/src/makers/controller-maker.ts
@@ -8,6 +8,25 @@ export async function controllerMaker(
   railsFile: RailsFile,
   workspace: RailsWorkspace
 ): Promise<SwitchFile[]> {
+  // For views, the controller name comes directly from the view directory name.
+  // Going through singularize→pluralize breaks non-noun names like
+  // "dashboard", "home", "api", etc.
+  if (railsFile.isView()) {
+    const controllerName = path.basename(railsFile.dirname) + '_controller.rb';
+    return [
+      {
+        checkedExists: false,
+        filename: path.join(
+          workspace.controllersPath,
+          railsFile.module,
+          controllerName
+        ),
+        title: 'Controller ' + controllerName,
+        type: 'controller',
+      },
+    ];
+  }
+
   return railsFile.possibleModelNames().map(possibleModelName => {
     const controllerName = pluralize(possibleModelName) + '_controller.rb';
     return {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -191,6 +191,12 @@ describe("Extension Tests", function () {
       await executeRawCommand("rails.switchToController");
       await expectProjectFile("app/controllers/big/lions_controller.rb");
     });
+
+    it("switch to non-resource controller (dashboard)", async () => {
+      await openFile("app/views/dashboard/index.html.erb");
+      await executeRawCommand("rails.switchToController");
+      await expectProjectFile("app/controllers/dashboard_controller.rb");
+    });
   });
 
   describe("from model file", () => {

--- a/src/test/project/app/controllers/dashboard_controller.rb
+++ b/src/test/project/app/controllers/dashboard_controller.rb
@@ -1,0 +1,2 @@
+class DashboardController < ApplicationController
+end


### PR DESCRIPTION
Hi there 👋 

Absolutely love this extension! Use it almost every day for a couple of years now.       
Mostly to quickly jump from a controller to its corresponding view.   
One thing I've noticed (but never enough to report or dig into) is that navigation from view → controller can be unreliable.

Controller → view works very consistently, but view → controller lookup currently relies on a singularize → pluralize approach in [`controllerMaker`](https://github.com/jemmyw/vscode-rails-fast-nav/blob/112a5ef9db76f07922363caf4c6a168cbe2a3a04/src/makers/controller-maker.ts#L7). This breaks for controllers whose names aren't simple plural nouns (e.g. home, dashboard, api, etc.).

Proposed fix:
When navigating from a view, derive the controller name directly from `path.basename(railsFile.dirname)`. Since Rails uses the view directory name as the controller base name by convention, no transformation is needed.
