### PR TITLE
Support multiple Rails app roots for engines and Packwerk packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,13 @@ Change the default view extension from `html.erb`:
 ```json
 "rails.viewFileExtension": "json.jbuilder"
 ```
+
+### Multiple app roots (Packwerk, Rails engines)
+
+For repositories with several `app` directories (Packwerk packs, Rails engines, or custom components), set `rails.appDirs` to glob patterns relative to the Rails root. When `rails.appDirs` is empty or omitted, only `rails.appDir` is used (default `app`).
+
+```json
+"rails.appDirs": ["app", "packs/*/app", "engines/*/app"]
+```
+
+Navigation picks the **longest matching** app root for the current file, so files under `packs/billing/app/...` resolve specs and views next to `packs/billing/spec/` when that folder exists.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rails-fast-nav",
-  "version": "1.3.4",
+  "version": "1.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rails-fast-nav",
-      "version": "1.3.4",
+      "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^8.1.0",
@@ -1262,7 +1262,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -2796,6 +2795,7 @@
         "yallist"
       ],
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2810,8 +2810,6 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2819,8 +2817,6 @@
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2831,8 +2827,6 @@
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2840,8 +2834,6 @@
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2853,8 +2845,6 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2862,8 +2852,6 @@
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2875,8 +2863,6 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2884,8 +2870,6 @@
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2896,8 +2880,6 @@
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2905,8 +2887,6 @@
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2914,8 +2894,6 @@
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2923,8 +2901,6 @@
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2935,8 +2911,6 @@
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2947,8 +2921,6 @@
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2956,8 +2928,6 @@
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -2971,8 +2941,6 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2983,8 +2951,6 @@
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2992,8 +2958,6 @@
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3011,8 +2975,6 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3031,8 +2993,6 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3040,8 +3000,6 @@
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3055,8 +3013,6 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3067,8 +3023,6 @@
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3080,8 +3034,6 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3089,8 +3041,6 @@
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3101,8 +3051,6 @@
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3116,8 +3064,6 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3125,8 +3071,6 @@
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3140,8 +3084,6 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3149,8 +3091,6 @@
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3162,8 +3102,6 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3174,8 +3112,6 @@
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3189,8 +3125,6 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3198,8 +3132,6 @@
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-      "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3218,8 +3150,6 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-      "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -3242,8 +3172,6 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3258,8 +3186,6 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3267,8 +3193,6 @@
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3280,8 +3204,6 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3295,8 +3217,6 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3307,8 +3227,6 @@
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3319,8 +3237,6 @@
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3331,8 +3247,6 @@
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3343,8 +3257,6 @@
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3355,8 +3267,6 @@
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3368,8 +3278,6 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3380,8 +3288,6 @@
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3389,8 +3295,6 @@
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
@@ -3407,8 +3311,6 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3416,8 +3318,6 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3434,8 +3334,6 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3449,8 +3347,6 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3458,8 +3354,6 @@
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3467,8 +3361,6 @@
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3476,8 +3368,6 @@
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3488,8 +3378,6 @@
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3497,8 +3385,6 @@
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3506,8 +3392,6 @@
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3518,8 +3402,6 @@
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3535,8 +3417,6 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3550,8 +3430,6 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3562,8 +3440,6 @@
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-      "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3583,8 +3459,6 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3592,8 +3466,6 @@
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3604,8 +3476,6 @@
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3613,8 +3483,6 @@
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5049,7 +4917,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -6204,6 +6071,7 @@
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "jszip": "^3.1.3",
         "rimraf": "^2.5.4",
@@ -7067,6 +6935,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
       "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7470,7 +7339,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -10288,32 +10156,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10324,16 +10184,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10344,48 +10200,36 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10395,32 +10239,24 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
-          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10430,16 +10266,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10456,8 +10288,6 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10472,16 +10302,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10491,8 +10317,6 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10502,8 +10326,6 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10514,24 +10336,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10541,16 +10357,12 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10560,16 +10372,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
-          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10580,8 +10388,6 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
-          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10591,8 +10397,6 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10602,16 +10406,12 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
-          "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10623,8 +10423,6 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-          "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10643,8 +10441,6 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10655,16 +10451,12 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-          "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
-          "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10675,8 +10467,6 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10689,24 +10479,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10716,24 +10500,18 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10744,24 +10522,18 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10774,8 +10546,6 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -10784,8 +10554,6 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10801,8 +10569,6 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10812,56 +10578,42 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10871,8 +10623,6 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10884,8 +10634,6 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10895,16 +10643,12 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
-          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10920,16 +10664,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -10939,16 +10679,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -13087,6 +12823,7 @@
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
+      "peer": true,
       "requires": {
         "jszip": "^3.1.3",
         "rimraf": "^2.5.4",
@@ -13812,7 +13549,8 @@
       "version": "3.9.9",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
       "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,14 @@
           "default": "app",
           "description": "Absolute or relative (to first workspace root) path to Rails app directory"
         },
+        "rails.appDirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "When non-empty, glob patterns for additional Rails app directories (engines, Packwerk packs, etc.). When empty, rails.appDir is used as the only app root."
+        },
         "rails.viewFileExtension": {
           "type": "string",
           "default": "html.erb",
@@ -116,7 +124,8 @@
     "test-prepare": "npm run test-compile && npm run copyTestProject",
     "test": "rimraf out; npm run test-prepare && extest setup-and-run -e test-resources/ext -o out/test/settings.json out/test/extension.test.js",
     "test-quick": "npm run test-prepare && extest run-tests -e test-resources/ext -o out/test/settings.json out/test/extension.test.js",
-    "copyTestProject": "cp -r src/test/project/* out/test; cp src/test/settings.json out/test"
+    "test:unit": "npm run test-compile && mocha out/test/rails-app-expand.unit.test.js",
+    "copyTestProject": "mkdir -p out/test && cp -a src/test/project/. out/test/ && cp src/test/settings.json out/test/"
   },
   "devDependencies": {
     "@types/chai": "^4.2.16",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,14 @@ import { commands } from './commands';
 import { RailsWorkspaceCache } from './rails-workspace';
 
 export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration('rails')) {
+        RailsWorkspaceCache.invalidateAllWorkspaces();
+      }
+    })
+  );
+
   Object.keys(commands).forEach(name => {
     const command = commands[name];
     const disposable = vscode.commands.registerCommand(

--- a/src/makers/controller-maker.ts
+++ b/src/makers/controller-maker.ts
@@ -8,12 +8,14 @@ export async function controllerMaker(
   railsFile: RailsFile,
   workspace: RailsWorkspace
 ): Promise<SwitchFile[]> {
+  const appRoot = railsFile.containingAppPath || workspace.appPath;
+  const controllersPath = path.join(appRoot, 'controllers');
   return railsFile.possibleModelNames().map(possibleModelName => {
     const controllerName = pluralize(possibleModelName) + '_controller.rb';
     return {
       checkedExists: false,
       filename: path.join(
-        workspace.controllersPath,
+        controllersPath,
         railsFile.module,
         controllerName
       ),

--- a/src/makers/fixture-maker.ts
+++ b/src/makers/fixture-maker.ts
@@ -1,6 +1,10 @@
 import { SwitchFile } from '../types';
 import { RailsFile } from '../rails-file';
-import { RailsWorkspace } from '../rails-workspace';
+import {
+  RailsWorkspace,
+  getEffectiveSpecRoot,
+  getEffectiveTestRoot,
+} from '../rails-workspace';
 import { pluralize } from 'inflected';
 import * as path from 'path';
 
@@ -9,10 +13,10 @@ export async function fixtureMaker(
   workspace: RailsWorkspace
 ): Promise<SwitchFile[]> {
   const hasSpecs = await workspace.hasSpecs();
-  const fixturesPath = path.join(
-    hasSpecs ? workspace.specPath : workspace.testPath,
-    'fixtures'
-  );
+  const baseRoot = hasSpecs
+    ? getEffectiveSpecRoot(railsFile, workspace)
+    : getEffectiveTestRoot(railsFile, workspace);
+  const fixturesPath = path.join(baseRoot, 'fixtures');
 
   return railsFile.possibleModelNames().map(modelName => {
     const basename =

--- a/src/makers/inverse-test-maker.ts
+++ b/src/makers/inverse-test-maker.ts
@@ -3,23 +3,62 @@ import { RailsFile } from '../rails-file';
 import { RailsWorkspace } from '../rails-workspace';
 import * as path from 'path';
 
-function inTestDir(workspace: RailsWorkspace, filename: string) {
-  return !path.relative(workspace.testPath, filename).startsWith('..');
-}
-
-function inSpecDir(workspace: RailsWorkspace, filename: string) {
-  return !path.relative(workspace.specPath, filename).startsWith('..');
-}
-
-function relativeToTestDir(
+function relativeFromSpecOrTestRoots(
   workspace: RailsWorkspace,
   filename: string
-): string {
-  if (inTestDir(workspace, filename)) {
-    return path.relative(workspace.testPath, filename);
-  } else if (inSpecDir(workspace, filename)) {
-    return path.relative(workspace.specPath, filename);
+): string | undefined {
+  const roots = [
+    ...workspace.getCandidateSpecRoots(),
+    ...workspace.getCandidateTestRoots(),
+  ].sort((a, b) => b.length - a.length);
+
+  for (const root of roots) {
+    const rel = path.relative(root, filename);
+    if (
+      rel &&
+      !path.isAbsolute(rel) &&
+      !rel.startsWith('..') &&
+      !rel.startsWith('..' + path.sep)
+    ) {
+      return rel;
+    }
   }
+  return undefined;
+}
+
+function resolveAppPathFromTestOrSpecFile(
+  workspace: RailsWorkspace,
+  railsFile: RailsFile
+): string {
+  const all = [
+    ...workspace.getCandidateSpecRoots(),
+    ...workspace.getCandidateTestRoots(),
+  ].sort((a, b) => b.length - a.length);
+
+  let matchedRoot: string | null = null;
+  for (const root of all) {
+    const rel = path.relative(root, railsFile.filename);
+    if (
+      rel &&
+      !path.isAbsolute(rel) &&
+      !rel.startsWith('..') &&
+      !rel.startsWith('..' + path.sep)
+    ) {
+      matchedRoot = root;
+      break;
+    }
+  }
+  if (!matchedRoot) {
+    return workspace.appPath;
+  }
+
+  const pkgRoot = path.dirname(matchedRoot);
+  const candidateApp = path.normalize(path.join(pkgRoot, 'app'));
+  const apps = workspace.getExpandedAppRoots();
+  if (apps.indexOf(candidateApp) >= 0) {
+    return candidateApp;
+  }
+  return workspace.appPath;
 }
 
 export function inverseTestMaker(
@@ -31,15 +70,20 @@ export function inverseTestMaker(
   }
 
   const basename = railsFile.basename.replace(/_(spec|test)/, '');
-  const relativeFilename = relativeToTestDir(workspace, railsFile.filename);
+  const relativeFilename = relativeFromSpecOrTestRoots(
+    workspace,
+    railsFile.filename
+  );
   if (!relativeFilename) {
     return [];
   }
   const relativePath = path.dirname(relativeFilename);
 
+  const appPath = resolveAppPathFromTestOrSpecFile(workspace, railsFile);
+
   return [
     {
-      filename: path.join(workspace.appPath, relativePath, basename),
+      filename: path.join(appPath, relativePath, basename),
       title: 'File',
       type: 'file',
     },

--- a/src/makers/spec-maker.ts
+++ b/src/makers/spec-maker.ts
@@ -1,8 +1,6 @@
 import { SwitchFile } from '../types';
 import { RailsFile } from '../rails-file';
-import { RailsWorkspace, relativeToAppDir } from '../rails-workspace';
-import { appendWithoutExt } from '../path-utils';
-import * as path from 'path';
+import { RailsWorkspace, getSpecPath } from '../rails-workspace';
 
 export function specMaker(
   railsFile: RailsFile,
@@ -10,10 +8,7 @@ export function specMaker(
 ): SwitchFile[] {
   return [
     {
-      filename: path.join(
-        workspace.specPath,
-        appendWithoutExt(relativeToAppDir(workspace, railsFile.filename), '_spec')
-      ),
+      filename: getSpecPath(railsFile, workspace),
       title: 'Spec file',
       type: 'spec',
     },

--- a/src/makers/test-maker.ts
+++ b/src/makers/test-maker.ts
@@ -1,19 +1,16 @@
 import { SwitchFile } from '../types';
 import { RailsFile } from '../rails-file';
-import { RailsWorkspace, relativeToAppDir } from '../rails-workspace';
-import { appendWithoutExt } from '../path-utils';
-import * as path from 'path';
+import { RailsWorkspace, getTestPath } from '../rails-workspace';
 
 export function testMaker(
   railsFile: RailsFile,
   workspace: RailsWorkspace
 ): SwitchFile[] {
-  return [{
-    filename: path.join(
-      workspace.testPath,
-      appendWithoutExt(relativeToAppDir(workspace, railsFile.filename), '_test')
-    ),
-    title: 'Test file',
-    type: 'test',
-  }];
+  return [
+    {
+      filename: getTestPath(railsFile, workspace),
+      title: 'Test file',
+      type: 'test',
+    },
+  ];
 }

--- a/src/rails-app-expand.ts
+++ b/src/rails-app-expand.ts
@@ -1,0 +1,87 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as glob from 'glob';
+
+function hasGlobChar(pattern: string): boolean {
+  return /[*?[\]{}]/.test(pattern);
+}
+
+function addDirIfPresent(roots: Set<string>, dir: string): void {
+  const norm = path.normalize(dir);
+  if (fs.existsSync(norm) && fs.statSync(norm).isDirectory()) {
+    roots.add(norm);
+  }
+}
+
+function sortAppRootsForPrimary(railsRoot: string, roots: string[]): string[] {
+  return roots.sort((a, b) => {
+    const aMain = path.dirname(a) === railsRoot;
+    const bMain = path.dirname(b) === railsRoot;
+    if (aMain !== bMain) {
+      return aMain ? -1 : 1;
+    }
+    if (a.length !== b.length) {
+      return a.length - b.length;
+    }
+    return a.localeCompare(b);
+  });
+}
+
+/**
+ * Expand app directory patterns under a Rails root (no VS Code; safe for unit tests).
+ */
+export function expandRailsAppRootsWithPatterns(
+  railsRoot: string,
+  patterns: string[]
+): string[] {
+  const roots = new Set<string>();
+  for (const pattern of patterns) {
+    const trimmed = pattern.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (path.isAbsolute(trimmed)) {
+      if (hasGlobChar(trimmed)) {
+        const matches = glob.sync(trimmed, { absolute: true, nodir: false });
+        for (const m of matches) {
+          addDirIfPresent(roots, m);
+        }
+      } else {
+        addDirIfPresent(roots, trimmed);
+      }
+      continue;
+    }
+
+    const joined = path.join(railsRoot, trimmed);
+    if (!hasGlobChar(trimmed)) {
+      addDirIfPresent(roots, joined);
+      continue;
+    }
+
+    const matches = glob.sync(joined, { nodir: false });
+    for (const m of matches) {
+      addDirIfPresent(roots, m);
+    }
+  }
+  return sortAppRootsForPrimary(railsRoot, [...roots]);
+}
+
+/**
+ * Longest matching app root directory that contains filePath.
+ */
+export function findContainingAppRoot(
+  filePath: string,
+  expandedAppRoots: string[]
+): string | null {
+  const norm = path.normalize(filePath);
+  const sep = path.sep;
+  const sorted = [...expandedAppRoots].sort((a, b) => b.length - a.length);
+  for (const root of sorted) {
+    const r = path.normalize(root);
+    if (norm === r || norm.startsWith(r + sep)) {
+      return r;
+    }
+  }
+  return null;
+}

--- a/src/rails-app-roots.ts
+++ b/src/rails-app-roots.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+import {
+  expandRailsAppRootsWithPatterns,
+  findContainingAppRoot,
+} from './rails-app-expand';
+
+const rootsCache = new Map<string, { sig: string; roots: string[] }>();
+
+export function getConfiguredAppDirPatterns(): string[] {
+  const config = vscode.workspace.getConfiguration('rails');
+  const appDirs = config.get<string[]>('appDirs');
+  if (Array.isArray(appDirs) && appDirs.length > 0) {
+    return appDirs.map(p => p.trim()).filter(Boolean);
+  }
+  return [config.get<string>('appDir', 'app')];
+}
+
+export function clearRailsAppRootsCache(): void {
+  rootsCache.clear();
+}
+
+export function clearRailsAppRootsCacheFor(railsRoot: string): void {
+  rootsCache.delete(railsRoot);
+}
+
+function patternsSignature(): string {
+  return JSON.stringify(getConfiguredAppDirPatterns());
+}
+
+export { expandRailsAppRootsWithPatterns, findContainingAppRoot };
+
+export function expandRailsAppRoots(railsRoot: string): string[] {
+  const sig = patternsSignature();
+  const hit = rootsCache.get(railsRoot);
+  if (hit && hit.sig === sig) {
+    return hit.roots;
+  }
+  const patterns = getConfiguredAppDirPatterns();
+  const roots = expandRailsAppRootsWithPatterns(railsRoot, patterns);
+  rootsCache.set(railsRoot, { sig, roots });
+  return roots;
+}

--- a/src/rails-file.ts
+++ b/src/rails-file.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { getAllMethodNames, getLastMethodName } from './ruby-methods';
 import { classify } from 'inflected';
 import { singularize } from 'inflected';
+import { expandRailsAppRoots, findContainingAppRoot } from './rails-app-roots';
 
 function isRailsRoot(filename: string): boolean {
   const railsBin = path.join(filename, 'bin', 'rails');
@@ -27,8 +28,9 @@ function getRailsRoot(filename: string): string | null {
  */
 export class RailsFile {
   private _parsed: path.ParsedPath;
-  private _railsRoot: string;
+  private _railsRoot: string | null;
   private _inApp: boolean;
+  private _containingAppPath: string | null;
 
   constructor(
     private _filename: string,
@@ -37,9 +39,16 @@ export class RailsFile {
   ) {
     this._parsed = path.parse(this._filename);
     this._railsRoot = getRailsRoot(this._parsed.dir);
-    this._inApp = path
-      .relative(this._railsRoot, _filename)
-      .startsWith('app' + path.sep);
+    if (this._railsRoot) {
+      const expanded = expandRailsAppRoots(this._railsRoot);
+      this._containingAppPath = findContainingAppRoot(_filename, expanded);
+    } else {
+      this._containingAppPath = null;
+    }
+    this._inApp =
+      this._containingAppPath !== null &&
+      (_filename === this._containingAppPath ||
+        _filename.startsWith(this._containingAppPath + path.sep));
   }
 
   get classname(): string {
@@ -64,7 +73,23 @@ export class RailsFile {
   get inApp(): boolean {
     return this._inApp;
   }
+
+  /** Nearest configured `.../app` directory containing this file, if any. */
+  get containingAppPath(): string | null {
+    return this._containingAppPath;
+  }
+
   get module(): string {
+    if (!this._railsRoot) {
+      return '';
+    }
+
+    if (this._inApp && this._containingAppPath) {
+      const rel = path.relative(this._containingAppPath, this._filename);
+      const parts = rel.split(path.sep);
+      return parts.slice(1, this.isView() ? -2 : -1).join(path.sep);
+    }
+
     const rel: string = path.relative(this._railsRoot, this._filename);
     return rel
       .split(path.sep)
@@ -88,7 +113,7 @@ export class RailsFile {
   }
 
   get railsRoot(): string {
-    return this._railsRoot;
+    return this._railsRoot!;
   }
 
   get fileType(): string {
@@ -114,11 +139,12 @@ export class RailsFile {
       return 'unknown';
     }
 
-    const rel: string = path.relative(
-      path.join(this._railsRoot, 'app'),
-      this._filename
-    );
-    return rel.split(path.sep)[0];
+    if (this._containingAppPath) {
+      const rel: string = path.relative(this._containingAppPath, this._filename);
+      return rel.split(path.sep)[0];
+    }
+
+    return 'unknown';
   }
 
   get methodName(): string {

--- a/src/rails-workspace.ts
+++ b/src/rails-workspace.ts
@@ -4,6 +4,11 @@ import * as vscode from 'vscode';
 import * as glob from 'glob';
 import { RailsFile } from './rails-file';
 import { appendWithoutExt } from './path-utils';
+import {
+  expandRailsAppRoots,
+  clearRailsAppRootsCacheFor,
+  clearRailsAppRootsCache,
+} from './rails-app-roots';
 
 /**
  * Some information about a Rails application at a given path.
@@ -13,7 +18,7 @@ import { appendWithoutExt } from './path-utils';
  */
 export class RailsWorkspace {
   private _knownFiles: { [index: string]: boolean } = {};
-  private _models: RailsFile[] = null;
+  private _models: RailsFile[] | null = null;
 
   constructor(private _path: string) {}
 
@@ -21,7 +26,12 @@ export class RailsWorkspace {
     return this._path;
   }
 
+  /** Primary app directory (top-level app preferred when present). */
   get appPath(): string {
+    const roots = this.getExpandedAppRoots();
+    if (roots.length > 0) {
+      return roots[0];
+    }
     const appDir = vscode.workspace.getConfiguration('rails').get('appDir', 'app');
     return path.resolve(this.path, appDir);
   }
@@ -32,6 +42,46 @@ export class RailsWorkspace {
 
   get testPath(): string {
     return path.join(this.path, 'test');
+  }
+
+  getExpandedAppRoots(): string[] {
+    return expandRailsAppRoots(this.path);
+  }
+
+  getCandidateSpecRoots(): string[] {
+    const roots: string[] = [];
+    const top = path.join(this.path, 'spec');
+    if (fs.existsSync(top)) {
+      roots.push(path.normalize(top));
+    }
+    for (const appRoot of this.getExpandedAppRoots()) {
+      const local = path.join(path.dirname(appRoot), 'spec');
+      if (fs.existsSync(local)) {
+        const n = path.normalize(local);
+        if (roots.indexOf(n) < 0) {
+          roots.push(n);
+        }
+      }
+    }
+    return roots;
+  }
+
+  getCandidateTestRoots(): string[] {
+    const roots: string[] = [];
+    const top = path.join(this.path, 'test');
+    if (fs.existsSync(top)) {
+      roots.push(path.normalize(top));
+    }
+    for (const appRoot of this.getExpandedAppRoots()) {
+      const local = path.join(path.dirname(appRoot), 'test');
+      if (fs.existsSync(local)) {
+        const n = path.normalize(local);
+        if (roots.indexOf(n) < 0) {
+          roots.push(n);
+        }
+      }
+    }
+    return roots;
   }
 
   get controllersPath(): string {
@@ -47,24 +97,24 @@ export class RailsWorkspace {
   }
 
   async hasSpecs(): Promise<boolean> {
-    return this.hasFile(this.specPath);
+    return Promise.resolve(this.getCandidateSpecRoots().length > 0);
   }
 
   async hasTests(): Promise<boolean> {
-    return this.hasFile(this.testPath);
+    return Promise.resolve(this.getCandidateTestRoots().length > 0);
   }
 
-  async hasFile(path: string): Promise<boolean> {
-    if (this._knownFiles[path]) {
+  async hasFile(pathToCheck: string): Promise<boolean> {
+    if (this._knownFiles[pathToCheck]) {
       return true;
     }
-    if (!path.startsWith(this.path)) {
+    if (!pathToCheck.startsWith(this.path)) {
       return false;
     }
 
-    const exists = await fs.pathExists(path);
+    const exists = await fs.pathExists(pathToCheck);
     if (exists) {
-      this._knownFiles[path] = true;
+      this._knownFiles[pathToCheck] = true;
     }
 
     return exists;
@@ -77,12 +127,27 @@ export class RailsWorkspace {
   async getModels() {
     if (this._models) return this._models;
 
-    const modelFiles = await new Promise<string[]>((res, rej) =>
-      glob(this.modelsPath + '/**/*.rb', (err, m) => {
-        if (err) return rej(err);
-        res(m);
-      })
-    );
+    const seen = new Set<string>();
+    const modelFiles: string[] = [];
+    for (const appRoot of this.getExpandedAppRoots()) {
+      const modelsDir = path.join(appRoot, 'models');
+      if (!fs.existsSync(modelsDir)) {
+        continue;
+      }
+      const found = await new Promise<string[]>((res, rej) =>
+        glob(modelsDir + '/**/*.rb', (err, m) => {
+          if (err) return rej(err);
+          res(m);
+        })
+      );
+      for (const f of found) {
+        const n = path.normalize(f);
+        if (!seen.has(n)) {
+          seen.add(n);
+          modelFiles.push(f);
+        }
+      }
+    }
 
     this._models = modelFiles.map<RailsFile>(filename => {
       return new RailsFile(filename, '', []);
@@ -91,15 +156,25 @@ export class RailsWorkspace {
     return this._models;
   }
 
-  clearCache() {
+  clearContentCache(): void {
     this._knownFiles = {};
     this._models = null;
+  }
+
+  clearCache() {
+    this.clearContentCache();
+    clearRailsAppRootsCacheFor(this.path);
   }
 }
 
 class RailsWorkspaceCacher {
   private _cache: { [index: string]: RailsWorkspace } = {};
   private _disposers: vscode.Disposable[] = [];
+
+  invalidateAllWorkspaces(): void {
+    clearRailsAppRootsCache();
+    Object.keys(this._cache).forEach(k => this._cache[k].clearContentCache());
+  }
 
   async fetch(workspacePath: string): Promise<RailsWorkspace> {
     if (this._cache[workspacePath]) {
@@ -108,12 +183,21 @@ class RailsWorkspaceCacher {
 
     const workspace = new RailsWorkspace(workspacePath);
 
-    const watchers = [
-      path.join(workspace.appPath, '**/*.rb'),
-      path.join(workspace.viewsPath, '**/*'),
-      path.join(workspace.specPath, '**/*.rb'),
-      path.join(workspace.testPath, '**/*.rb'),
-    ].map(glob => vscode.workspace.createFileSystemWatcher(glob, false, true));
+    const watchGlobs: string[] = [];
+    for (const appRoot of workspace.getExpandedAppRoots()) {
+      watchGlobs.push(path.join(appRoot, '**/*.rb'));
+      watchGlobs.push(path.join(appRoot, 'views', '**/*'));
+    }
+    for (const specRoot of workspace.getCandidateSpecRoots()) {
+      watchGlobs.push(path.join(specRoot, '**/*.rb'));
+    }
+    for (const testRoot of workspace.getCandidateTestRoots()) {
+      watchGlobs.push(path.join(testRoot, '**/*.rb'));
+    }
+
+    const watchers = watchGlobs.map(g =>
+      vscode.workspace.createFileSystemWatcher(g, false, true)
+    );
 
     watchers.forEach(watcher => {
       watcher.onDidCreate(() => workspace.clearCache());
@@ -139,6 +223,32 @@ class RailsWorkspaceCacher {
  */
 export const RailsWorkspaceCache = new RailsWorkspaceCacher();
 
+export function getEffectiveSpecRoot(
+  railsFile: RailsFile,
+  workspace: RailsWorkspace
+): string {
+  if (railsFile.containingAppPath) {
+    const local = path.join(path.dirname(railsFile.containingAppPath), 'spec');
+    if (fs.existsSync(local)) {
+      return local;
+    }
+  }
+  return path.join(workspace.path, 'spec');
+}
+
+export function getEffectiveTestRoot(
+  railsFile: RailsFile,
+  workspace: RailsWorkspace
+): string {
+  if (railsFile.containingAppPath) {
+    const local = path.join(path.dirname(railsFile.containingAppPath), 'test');
+    if (fs.existsSync(local)) {
+      return local;
+    }
+  }
+  return path.join(workspace.path, 'test');
+}
+
 /**
  * Given a rails file, return it's location in the app/* directory of the
  * workspace.
@@ -149,10 +259,12 @@ export const RailsWorkspaceCache = new RailsWorkspaceCacher();
  */
 export function locationWithinAppLocation(
   filename: string,
-  workspace: RailsWorkspace
+  workspace: RailsWorkspace,
+  appRoot?: string
 ): string {
+  const base = appRoot || workspace.appPath;
   return path
-    .dirname(relativeToAppDir(workspace, filename))
+    .dirname(path.relative(base, filename))
     .split(path.sep)
     .slice(1)
     .join(path.sep);
@@ -170,7 +282,7 @@ export function relativeToRootDir(
   filename?: string
 ) {
   if (!filename) {
-    return filename => relativeToRootDir(workspace, filename);
+    return (fn: string) => relativeToRootDir(workspace, fn);
   }
   return path.relative(workspace.path, filename);
 }
@@ -187,7 +299,7 @@ export function relativeToAppDir(
 ): string;
 export function relativeToAppDir(workspace: RailsWorkspace, filename?: string) {
   if (!filename) {
-    return filename => relativeToAppDir(workspace, filename);
+    return (fn: string) => relativeToAppDir(workspace, fn);
   }
   return path.relative(workspace.appPath, filename);
 }
@@ -205,12 +317,14 @@ export function getTestPath(
   railsFile: RailsFile,
   workspace: RailsWorkspace
 ): string {
-  const relFn = (railsFile.inApp ? relativeToAppDir : relativeToRootDir)(
-    workspace
-  );
+  const testRoot = getEffectiveTestRoot(railsFile, workspace);
+  const appBase = railsFile.containingAppPath || workspace.appPath;
+  const relFn = railsFile.inApp
+    ? (fn: string) => path.relative(appBase, fn)
+    : relativeToRootDir(workspace);
 
   return path.join(
-    workspace.testPath,
+    testRoot,
     appendWithoutExt(relFn(railsFile.filename), '_test')
   );
 }
@@ -219,12 +333,14 @@ export function getSpecPath(
   railsFile: RailsFile,
   workspace: RailsWorkspace
 ): string {
-  const relFn = (railsFile.inApp ? relativeToAppDir : relativeToRootDir)(
-    workspace
-  );
+  const specRoot = getEffectiveSpecRoot(railsFile, workspace);
+  const appBase = railsFile.containingAppPath || workspace.appPath;
+  const relFn = railsFile.inApp
+    ? (fn: string) => path.relative(appBase, fn)
+    : relativeToRootDir(workspace);
 
   return path.join(
-    workspace.specPath,
+    specRoot,
     appendWithoutExt(relFn(railsFile.filename), '_spec')
   );
 }
@@ -237,9 +353,11 @@ export function getViewPath(workspace: RailsWorkspace, railsFile: RailsFile) {
     .split('_')
     .slice(0, -1)
     .join('_');
+  const appRoot = railsFile.containingAppPath || workspace.appPath;
+  const viewsPath = path.join(appRoot, 'views');
   return path.join(
-    workspace.viewsPath,
-    locationWithinAppLocation(railsFile.filename, workspace),
+    viewsPath,
+    locationWithinAppLocation(railsFile.filename, workspace, appRoot),
     justName
   );
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -206,4 +206,44 @@ describe("Extension Tests", function () {
       await expectProjectFile("spec/models/cat_spec.rb");
     });
   });
+
+  describe("Packwerk-style package (rails.appDirs)", () => {
+    it("switch to view from package controller", async () => {
+      await openFile(
+        "packs/billing/app/controllers/billing/invoices_controller.rb"
+      );
+      await gotoLine(3);
+      await executeRawCommand("rails.switchToView");
+      await expectProjectFile(
+        "packs/billing/app/views/billing/invoices/show.html.erb"
+      );
+    });
+
+    it("switch to model from package controller", async () => {
+      await openFile(
+        "packs/billing/app/controllers/billing/invoices_controller.rb"
+      );
+      await executeRawCommand("rails.switchToModel");
+      await expectProjectFile("packs/billing/app/models/billing/invoice.rb");
+    });
+
+    it("switch to spec from package model", async () => {
+      await openFile("packs/billing/app/models/billing/invoice.rb");
+      await executeRawCommand("rails.switchToSpec");
+      await expectProjectFile("packs/billing/spec/models/billing/invoice_spec.rb");
+    });
+  });
+
+  describe("Rails engine (rails.appDirs)", () => {
+    it("switch to view from engine controller", async () => {
+      await openFile(
+        "engines/documents/app/controllers/documents/documents_controller.rb"
+      );
+      await gotoLine(3);
+      await executeRawCommand("rails.switchToView");
+      await expectProjectFile(
+        "engines/documents/app/views/documents/documents/index.html.erb"
+      );
+    });
+  });
 });

--- a/src/test/project/.vscode/settings.json
+++ b/src/test/project/.vscode/settings.json
@@ -1,2 +1,3 @@
 {
+  "rails.appDirs": ["app", "packs/*/app", "engines/*/app"]
 }

--- a/src/test/project/engines/documents/app/controllers/documents/documents_controller.rb
+++ b/src/test/project/engines/documents/app/controllers/documents/documents_controller.rb
@@ -1,0 +1,6 @@
+module Documents
+  class DocumentsController < ApplicationController
+    def index
+    end
+  end
+end

--- a/src/test/project/engines/documents/app/views/documents/documents/index.html.erb
+++ b/src/test/project/engines/documents/app/views/documents/documents/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Documents</h1>

--- a/src/test/project/packs/billing/app/controllers/billing/invoices_controller.rb
+++ b/src/test/project/packs/billing/app/controllers/billing/invoices_controller.rb
@@ -1,0 +1,6 @@
+module Billing
+  class InvoicesController < ApplicationController
+    def show
+    end
+  end
+end

--- a/src/test/project/packs/billing/app/models/billing/invoice.rb
+++ b/src/test/project/packs/billing/app/models/billing/invoice.rb
@@ -1,0 +1,4 @@
+module Billing
+  class Invoice
+  end
+end

--- a/src/test/project/packs/billing/app/views/billing/invoices/show.html.erb
+++ b/src/test/project/packs/billing/app/views/billing/invoices/show.html.erb
@@ -1,0 +1,1 @@
+<p>invoice</p>

--- a/src/test/project/packs/billing/spec/models/billing/invoice_spec.rb
+++ b/src/test/project/packs/billing/spec/models/billing/invoice_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe Billing::Invoice do
+end

--- a/src/test/rails-app-expand.unit.test.ts
+++ b/src/test/rails-app-expand.unit.test.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  expandRailsAppRootsWithPatterns,
+  findContainingAppRoot,
+} from '../rails-app-expand';
+
+describe('rails-app-expand', () => {
+  let tmp: string;
+  let railsRoot: string;
+
+  beforeEach(async () => {
+    tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'rfn-'));
+    railsRoot = path.join(tmp, 'myapp');
+    await fs.ensureFile(path.join(railsRoot, 'bin', 'rails'));
+    await fs.ensureDir(path.join(railsRoot, 'app', 'models'));
+    await fs.ensureDir(path.join(railsRoot, 'packs', 'billing', 'app', 'models', 'billing'));
+    await fs.ensureDir(path.join(railsRoot, 'engines', 'docs', 'app', 'controllers'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmp);
+  });
+
+  it('expands glob patterns and prefers top-level app', () => {
+    const roots = expandRailsAppRootsWithPatterns(railsRoot, [
+      'packs/*/app',
+      'engines/*/app',
+      'app',
+    ]);
+    expect(roots.length).to.equal(3);
+    expect(roots[0]).to.equal(path.join(railsRoot, 'app'));
+  });
+
+  it('finds the longest matching app root for a nested file', () => {
+    const roots = expandRailsAppRootsWithPatterns(railsRoot, [
+      'app',
+      'packs/*/app',
+    ]);
+    const modelFile = path.join(
+      railsRoot,
+      'packs',
+      'billing',
+      'app',
+      'models',
+      'billing',
+      'invoice.rb'
+    );
+    const hit = findContainingAppRoot(modelFile, roots);
+    expect(hit).to.equal(path.join(railsRoot, 'packs', 'billing', 'app'));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `rails.appDirs` workspace setting (array of glob patterns). When it is empty, behavior matches the existing single `rails.appDir` setting.
- Resolves the nearest matching app root for the active file (longest path wins) so navigation works under `packs/*/app`, `engines/*/app`, and similar layouts.
- Classifies controllers, models, and views relative to that app root; discovers models across all configured app roots; uses package-local `spec/` and `test/` when present.
- Clears expansion and workspace caches when `rails` configuration changes.
- Adds unit tests for glob expansion, integration-style extension tests for a Packwerk-shaped package and a Rails engine, and README documentation.

Fixes #34.

Refs #38.

## Why

The extension assumed a single top-level `app/` tree. Controllers and views under Packwerk packs or Rails engines live under additional `app` directories, so "switch to view" and related commands failed for those paths. Configurable app-root globs address Packwerk, engines, and other multi-root layouts without parsing `packwerk.yml`.

## Changes

- New `rails.appDirs` contribution in `package.json`; `copyTestProject` copies hidden files (e.g. `.vscode`) so tests can set folder-scoped `rails.appDirs`.
- `src/rails-app-expand.ts` and `src/rails-app-roots.ts` for pattern expansion and caching.
- `RailsFile` exposes `containingAppPath` and derives `inApp`, `fileType`, and `module` from the nearest app root.
- `RailsWorkspace` aggregates app roots, spec/test candidates, model globs, file watchers, and effective spec/test paths.
- Makers and inverse test navigation use the active app root and effective spec/test roots.
- `npm run test:unit` runs Mocha tests for expansion helpers.

## Example configuration

```json
{
  "rails.appDirs": ["app", "packs/*/app", "engines/*/app"]
}
```

## Test plan

- [x] `npm run test-compile`
- [x] `npm run test:unit`
- [ ] `npm run test-quick` (VS Code extension UI tests)
- [ ] Manual: from `app/controllers/...`, switch to model / view / spec unchanged
- [ ] Manual: from `packs/.../app/controllers/...`, switch to view under the same pack
- [ ] Manual: from `engines/.../app/controllers/...`, switch to view under the same engine
- [ ] Manual: model list includes models from configured extra app roots